### PR TITLE
REF/FIX: fix py39-lxml + move packages to variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,9 @@ endif
 
 all: ssh-setup run-provision
 
+clean:
+	rm -f $(PLC_HOST_VARS)
+
 ssh-setup:
 	if [ ! -f "$(SSH_KEY_FILENAME)" ]; then \
 		ssh-keygen -t rsa -f "$(SSH_KEY_FILENAME)"; \
@@ -61,4 +64,4 @@ add-route:
 	# command-line arguments.
 	bash add_route.sh
 
-.PHONY: all ssh-setup ssh run-provision run-bootstrap add-route
+.PHONY: all clean ssh-setup ssh run-provision run-bootstrap add-route

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A repository for trying out Ansible provisioning of TwinCAT BSD PLCs.
 If you have a physical PLC to use, you'll only need the following:
 
 * bash
-* ansible, lxml in a working Python 3.9+ environment
+* ansible
 * ``gettext`` to interpolate the host variable template
 
 To work using a PLC Virtual Machine (i.e., without a physical PLC), you'll also

--- a/group_vars/tcbsd_plcs/vars.yml
+++ b/group_vars/tcbsd_plcs/vars.yml
@@ -6,6 +6,11 @@ ansible_become_method: doas
 ansible_become_password: 1  # TODO: vault
 ansible_python_interpreter: /usr/local/bin/python3
 
+# FreeBSD packages are *required* at the moment for py39-lxml.
+# Beckhoff may re-add py39-lxml in the future, so re-evaluate this at that
+# point.
+enable_freebsd_packages: true
+
 # This is the default of 32MB. Set to 67108864 for 64MB of router memory.
 tc_locked_memory_size_bytes: 33554432
 
@@ -18,11 +23,67 @@ tc_use_bash: true
 # Install C/C++ development tools (approximately 1.8GB):
 tc_install_cpp_dev_tools: true
 
-# Install these additional packages:
+# Packages to install:
+tc_libraries:
+# - TC31-OrderNo                             # Mapping of TwinCAT order numbers to TC/BSD package names
+# - TC31-TcIoPtp                             # TcIoPtp | TC3 Precise Time Protocol
+# - TC31-TcOsSys                             # TwinCAT runtime component TcOsSys.dll and TwinCAT license text
+# - TC31-XAR                                 # TwinCAT System Service
+# - TC31-XAR-EtherCATSlave                   # TwinCAT EtherCATSlave driver
+# - TCBSD-CrossBuildSDK                      # SDK for TC/BSD cross-compilation
+# - TCBSD-Install-Scripts                    # TCBSD installer scripts
+# - TF1810-PLC-HMI-Web                       # TF1810 | TC3 PLC HMI Web
+# - TF2000-HMI-Server                        # TF2000-HMI-Server
+# - TF3300-Scope-Server-IoT                  #
+# - TF3500-Analytics-Logger                  # TF3500 | TC3 Analytics Logger
+# - TF360x-Condition-Monitoring              # TF360x | TC3 Condition Monitoring
+# - TF3650-Power-Monitoring                  # TF3650 | TC3 Power Monitoring
+# - TF3800-Machine-Learning                  # TF3800 | TC3 Machine Learning
+# - TF5000-NC-PTP                            # TwinCAT NC PTP driver
+# - TF5100-NCI                               # TF5100 | TC3 NC I
+# - TF5210-CNC-E                             # TF5210 | TC3 CNC E
+# - TF5850-XTS-Technology                    # TF5850 | XTS Technology
+# - TF6000-ADS-Comm-Lib                      # TF6000 | TC3 ADS Communication Library
+# - TF6100-OPC-UA-beta                       # TF6100 | TC3 OPC UA
+# - TF6230-Parallel-Redundancy-Protocol      # TF6230 | TC3 Parallel Redundancy Protocol
+# - TF6250-Modbus-TCP                        # TF6250 | TC3 Modbus TCP
+# - TF627x-PROFINET-RT                       # TwinCAT PROFINET RT driver
+# - TF6280-EtherNetIP                        # This package was replaces by TF628x-EthernetIP
+# - TF628x-EtherNetIP                        # TwinCAT EtherNet/IP driver
+- TF6310-TCP-IP                            # TF6310 | TC3 TCP/IP
+# - TF6340-Serial-Communication-beta         # TF6340 | TC3 Serial Communication
+# - TF6420-Database-Server                   # TF6420 | TC3 Database Server
+# - TF6421-XML-Server                        # TF6421 | TC3 XML Server
+# - TF6620-S7-Comm                           # TF6620 | S7 Communication
+# - TF8020-BACnet                            # TwinCAT BACnet driver
+# - TF8310-Wind-Framework                    # TF8310 | TC3 Wind Framework
+
+tc_tools_packages:
+  - TcAdsTool                    # TcAdsTool | Use the power of ADS from your command line
+  - TcAmsLogger                  # TwinCAT ADS Monitor - AMS Logger
+  # - TcBackup                   # Tools to easily create and restore full system backups
+  # - TcBackup-Gui-Installer     # Tools to easily create and restore full system backups
+  # - TcCoreConf                 # TwinCAT CPU core configuration tool
+  # - TcCppUtils2.0              #
+  # - TcEventLoggerAdsProxy      # TcEventLoggerAdsProxy
+  # - TcImportCert               # TcImportCert | Import TwinCAT OEM certificate data into TwinCAT registry
+  # - TcPalDrv                   # TwinCAT PAL driver
+  # - TcTypeSystem2.7            #
+  # - TcTypeSystem2.8            #
+  # - TcUsb                      # TwinCAT USB driver
+
 tc_packages_to_install:
   - git
   - vim
   - ripgrep
+
+# Packages only available via pip can be installed using this.
+# py39-pip will only be installed if you marked it here.
+# As far as the security implications go: well, that's up to you!
+tc_install_pip_packages:
+#   - pytmc
+# Uninstall pip after using it?
+tc_uninstall_pip: true
 
 # Configure the following static routes (and only those):
 # NOTE: if you don't want to run my arbitrary module, use this instead

--- a/tcbsd-provision-playbook.yaml
+++ b/tcbsd-provision-playbook.yaml
@@ -5,18 +5,53 @@
     - name: Verify connectivity with ping
       ping:
 
+    - name: Enable FreeBSD packages
+      when: enable_freebsd_packages
+      ansible.builtin.file:
+        # This file contains a setting to disable FreeBSD packages.
+        # We remove it in order to enable access to upstream packages.
+        path: /usr/local/etc/pkg/repos/FreeBSD.conf
+        state: absent
+
     - name: Install helpful system packages
       ansible.builtin.package:
         name:
+          # TCBSD 13 stable packages are listed here:
+          # https://tcbsd.beckhoff.com/TCBSD/13/stable/packages/packagesite.html
           - bash
           - bash-completion
           - htop
+          # Beyond bootstrapping, python39 is here to keep it up-to-date:
+          - python39
+          # Support for hostname -> IP -> ip_to_ams_net_id
+          - py39-dnspython
+          # py39-lxml may come from OpenBSD; Beckhoff removed it from theirs:
           - py39-lxml
-          - python39  # beyond bootstrapping, this is here to keep it up-to-date
           - rsync
-          # - py39-pip  # probably not a good idea
-          # - zsh
         state: latest
+
+    - name: Install pip
+      # Packages only available via pip will be installed after this
+      # As far as the security implications go: well, that's up to you!
+      when: tc_install_pip_packages
+      ansible.builtin.package:
+        name:
+          - py39-pip
+        state: latest
+
+    - name: Install pip dependencies if required
+      when: tc_install_pip_packages
+      ansible.builtin.pip:
+        name: "{{ tc_install_pip_packages }}"
+
+    - name: Install pip
+      # Packages only available via pip will be installed after this
+      # As far as the security implications go: well, that's up to you!
+      when: tc_uninstall_pip
+      ansible.builtin.package:
+        name:
+          - py39-pip
+        state: absent
 
     - name: Install user-specified system packages
       ansible.builtin.package:
@@ -25,19 +60,7 @@
 
     - name: Install TwinCAT tools
       ansible.builtin.package:
-        name:
-          - TcAdsTool                                # TcAdsTool | Use the power of ADS from your command line
-          - TcAmsLogger                              # TwinCAT ADS Monitor - AMS Logger
-          # - TcBackup                                 # Tools to easily create and restore full system backups
-          # - TcBackup-Gui-Installer                   # Tools to easily create and restore full system backups
-          # - TcCoreConf                               # TwinCAT CPU core configuration tool
-          # - TcCppUtils2.0                            #
-          # - TcEventLoggerAdsProxy                    # TcEventLoggerAdsProxy
-          # - TcImportCert                             # TcImportCert | Import TwinCAT OEM certificate data into TwinCAT registry
-          # - TcPalDrv                                 # TwinCAT PAL driver
-          # - TcTypeSystem2.7                          #
-          # - TcTypeSystem2.8                          #
-          # - TcUsb                                    # TwinCAT USB driver
+        name: "{{ tc_tools_packages }}"
         state: latest
 
     - name: Install C/C++ development tools
@@ -49,48 +72,10 @@
         state: latest
       when: tc_install_cpp_dev_tools
 
-    - name: Install required TwinCAT Libraries
+    - name: Install user TwinCAT Libraries
       ansible.builtin.package:
-        name:
-          # - TC31-OrderNo                             # Mapping of TwinCAT order numbers to TC/BSD package names
-          # - TC31-TcIoPtp                             # TcIoPtp | TC3 Precise Time Protocol
-          # - TC31-TcOsSys                             # TwinCAT runtime component TcOsSys.dll and TwinCAT license text
-          # - TC31-XAR                                 # TwinCAT System Service
-          # - TC31-XAR-EtherCATSlave                   # TwinCAT EtherCATSlave driver
-          # - TCBSD-CrossBuildSDK                      # SDK for TC/BSD cross-compilation
-          # - TCBSD-Install-Scripts                    # TCBSD installer scripts
-          # - TF1810-PLC-HMI-Web                       # TF1810 | TC3 PLC HMI Web
-          # - TF2000-HMI-Server                        # TF2000-HMI-Server
-          # - TF3300-Scope-Server-IoT                  #
-          # - TF3500-Analytics-Logger                  # TF3500 | TC3 Analytics Logger
-          # - TF360x-Condition-Monitoring              # TF360x | TC3 Condition Monitoring
-          # - TF3650-Power-Monitoring                  # TF3650 | TC3 Power Monitoring
-          # - TF3800-Machine-Learning                  # TF3800 | TC3 Machine Learning
-          # - TF5000-NC-PTP                            # TwinCAT NC PTP driver
-          # - TF5100-NCI                               # TF5100 | TC3 NC I
-          # - TF5210-CNC-E                             # TF5210 | TC3 CNC E
-          # - TF5850-XTS-Technology                    # TF5850 | XTS Technology
-          # - TF6000-ADS-Comm-Lib                      # TF6000 | TC3 ADS Communication Library
-          # - TF6100-OPC-UA-beta                       # TF6100 | TC3 OPC UA
-          # - TF6230-Parallel-Redundancy-Protocol      # TF6230 | TC3 Parallel Redundancy Protocol
-          # - TF6250-Modbus-TCP                        # TF6250 | TC3 Modbus TCP
-          # - TF627x-PROFINET-RT                       # TwinCAT PROFINET RT driver
-          # - TF6280-EtherNetIP                        # This package was replaces by TF628x-EthernetIP
-          # - TF628x-EtherNetIP                        # TwinCAT EtherNet/IP driver
-          - TF6310-TCP-IP                            # TF6310 | TC3 TCP/IP
-          # - TF6340-Serial-Communication-beta         # TF6340 | TC3 Serial Communication
-          # - TF6420-Database-Server                   # TF6420 | TC3 Database Server
-          # - TF6421-XML-Server                        # TF6421 | TC3 XML Server
-          # - TF6620-S7-Comm                           # TF6620 | S7 Communication
-          # - TF8020-BACnet                            # TwinCAT BACnet driver
-          # - TF8310-Wind-Framework                    # TF8310 | TC3 Wind Framework
+        name: "{{ tc_libraries }}"
         state: latest
-
-    # Additional pip packages? Add py39-pip  above and do:
-    # - name: Install pip dependencies if required
-    #   ansible.builtin.pip:
-    #     name: lxml >=2.3.0
-    # Want to use hostname -> IP -> ip_to_ams_net_id? Add py39-dnspython to the list
 
     - name: Set the AMS Net ID
       community.general.xml:


### PR DESCRIPTION
* Last-minute touch-ups after I found that py39-lxml was removed without notice from the Beckhoff 13 stable package server
    * Packages are listed here: https://tcbsd.beckhoff.com/TCBSD/13/stable/packages/packagesite.html
    * py39-lxml is in testing, so it may return: https://tcbsd.beckhoff.com/TCBSD/13/testing/packages/packagesite.html
    * py38-lxml is in V12 but I don't want to revert this
* So, in my opinion, the best path forward here is enabling the OpenBSD repositories as a fallback for when TwinCAT repos don't have the packages
   * This is done by removing a stub file that Beckhoff installs specifically disabling the OpenBSD repo
* Additionally, this moves packages to be variables instead of baked into the playbook
   * This just seems to be good or at least better practice
   * I think that "normal" playbooks may have these dependencies baked into individual roles
* Roles are not really in use in this repository - and that may be something to follow up on for actual production deployments
* Adds optional step to install pip packages (and then subsequently remove pip)