### PR TITLE
WIP: deploy to plc-tst-bsd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,11 +41,11 @@ ssh-setup:
 	if [ ! -f "$(SSH_KEY_FILENAME)" ]; then \
 		ssh-keygen -t rsa -f "$(SSH_KEY_FILENAME)"; \
 	fi
-	ssh-copy-id -i "$(SSH_KEY_FILENAME)" "$(PLC_USERNAME)@$(PLC_IP)"
-	$(MAKE) ssh SSH_ARGS='echo "Successfully logged in with the key to $(PLC_IP)"'
+	ssh-copy-id -i "$(SSH_KEY_FILENAME)" "$(PLC_USERNAME)@$(PLC_HOSTNAME)"
+	$(MAKE) ssh SSH_ARGS='echo "Successfully logged in with the key to $(PLC_HOSTNAME)"'
 
 ssh:
-	ssh -i "$(SSH_KEY_FILENAME)" "$(PLC_USERNAME)@$(PLC_IP)" $(SSH_ARGS)
+	ssh -i "$(SSH_KEY_FILENAME)" "$(PLC_USERNAME)@$(PLC_HOSTNAME)" $(SSH_ARGS)
 
 $(PLC_HOST_VARS): Makefile tcbsd-plc.yaml.template
 	# This substitutes our local environment into ``host_inventory.yaml.template``

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,3 +2,6 @@
 inventory = ./inventory/
 deprecation_warnings = True
 role_path = ./roles
+
+[ssh_connection]
+ssh_args =

--- a/group_vars/tcbsd_plcs/vars.yml
+++ b/group_vars/tcbsd_plcs/vars.yml
@@ -1,6 +1,6 @@
 ---
 ansible_user: Administrator
-ansible_ssh_private_key_file: /Users/klauer/Repos/twincat-bsd-ansible-testing/tcbsd_key_rsa
+ansible_ssh_private_key_file: /cds/home/z/zlentz/github/twincat-bsd-ansible/tcbsd_key_rsa
 ansible_become: true
 ansible_become_method: doas
 ansible_become_password: 1  # TODO: vault
@@ -17,7 +17,7 @@ tc_locked_memory_size_bytes: 33554432
 # Heap memory size is not specified by default. If you wish to change the
 # default, set this to greater than 0 (e.g., 1024).  This must be
 # greater than the locked memory size for the router, above.
-tc_heap_memory_size_mb: 0
+tc_heap_memory_size_mb: 2048
 # Install and use bash in place of sh:
 tc_use_bash: true
 # Install C/C++ development tools (approximately 1.8GB):
@@ -91,7 +91,4 @@ tc_uninstall_pip: true
 tc_set_fixed_static_routes: []
 
 # Alternatively, only add missing routes from the list:
-tc_add_missing_static_routes:
-  - name: PC98125
-    address: 192.168.2.110
-    net_id: 192.168.2.110.1.1
+tc_add_missing_static_routes: []

--- a/inventory/plcs.yaml
+++ b/inventory/plcs.yaml
@@ -5,4 +5,4 @@ plcs:
 
 tcbsd_plcs:
   hosts:
-    test-plc-01:
+    plc-tst-bsd:


### PR DESCRIPTION
I don't think I'm going to merge this, but I want to keep a record of what I tried first to get the playbooks to run on plc-tst-bsd. I think I will need to make more changes:

- Restructure to easily allow running on one plc at a time, or only on plcs in one hutch for example
- bifurcate between vm plcs and real plcs on-site at lcls
- make it easier to overwrite commonly-overwritten settings on a per-plc basis

And then, additionally, I'll need to add more automated steps based on what I've learned so far