### PR TITLE
ENH: more steps, full remote setup from factory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 TCBSD*.vdi
 TCBSD*.iso
 venv
+*.swp

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ A repository for trying out Ansible provisioning of TwinCAT BSD PLCs.
 
 ### Quick start: set up a new plc in prod
 1. clone the repo
-2. run ``./scripts/first_time_setup.sh your-plc-name``
-3. Edit ``./inventory/plcs.yaml`` to add your plc (and possibly an appropriate group)
-4. Edit ``./host_vars/your-plc-name/vars.yaml`` if you'd like to change settings
+2. Edit ``./inventory/plcs.yaml`` to add your plc (and possibly an appropriate group)
+3. run ``./scripts/first_time_setup.sh your-plc-name``
+4. Optionally edit ``./host_vars/your-plc-name/vars.yaml`` if you'd like to change settings
 3. run ``./scripts/provision_plcs.sh your-plc-name``
 4. commit and submit the file edits as a PR
 

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,3 +2,6 @@
 inventory = ./inventory/
 deprecation_warnings = True
 role_path = ./roles
+
+[ssh_connection]
+ssh_args =

--- a/group_vars/tcbsd_plcs/vars.yml
+++ b/group_vars/tcbsd_plcs/vars.yml
@@ -15,10 +15,12 @@ use_psproxy: true
 use_psntp: true
 
 # set static IP on x000 (mac id 2)
-x000_static: 192.168.1.10
+x000_set_static_ip: true
+x000_static_ip: 192.168.1.10
 
 # We can set the PLC's timezone, which is largely cosmetic
 # See /usr/share/zoneinfo/ on the PLC for options
+set_plc_timezone: true
 plc_timezone: America/Los_Angeles
 
 # This is the default of 32MB. Set to 67108864 for 64MB of router memory.

--- a/group_vars/tcbsd_plcs/vars.yml
+++ b/group_vars/tcbsd_plcs/vars.yml
@@ -14,6 +14,9 @@ enable_freebsd_packages: true
 use_psproxy: true
 use_psntp: true
 
+# set static IP on x000 (mac id 2)
+x000_static: 192.168.1.10
+
 # We can set the PLC's timezone, which is largely cosmetic
 # See /usr/share/zoneinfo/ on the PLC for options
 plc_timezone: America/Los_Angeles

--- a/group_vars/tcbsd_plcs/vars.yml
+++ b/group_vars/tcbsd_plcs/vars.yml
@@ -10,6 +10,14 @@ ansible_python_interpreter: /usr/local/bin/python3
 # point.
 enable_freebsd_packages: true
 
+# psproxy and psntp are currently needed to get bsd and package updates while on the lcls cds networks
+use_psproxy: true
+use_psntp: true
+
+# We can set the PLC's timezone, which is largely cosmetic
+# See /usr/share/zoneinfo/ on the PLC for options
+plc_timezone: America/Los_Angeles
+
 # This is the default of 32MB. Set to 67108864 for 64MB of router memory.
 tc_locked_memory_size_bytes: 33554432
 

--- a/group_vars/tcbsd_vms/vars.yml
+++ b/group_vars/tcbsd_vms/vars.yml
@@ -10,6 +10,14 @@ ansible_python_interpreter: /usr/local/bin/python3
 # point.
 enable_freebsd_packages: true
 
+# psproxy and psntp are currently needed to get bsd and package updates while on the lcls cds networks
+use_psproxy: false
+use_psntp: false
+
+# We can set the PLC's timezone, which is largely cosmetic
+# See /usr/share/zoneinfo/ on the PLC for options
+plc_timezone:
+
 # This is the default of 32MB. Set to 67108864 for 64MB of router memory.
 tc_locked_memory_size_bytes: 33554432
 

--- a/group_vars/tcbsd_vms/vars.yml
+++ b/group_vars/tcbsd_vms/vars.yml
@@ -15,11 +15,13 @@ use_psproxy: false
 use_psntp: false
 
 # set static IP on x000 (mac id 2)
-x000_static:
+x000_set_static_ip: false
+x000_static_ip: 192.168.1.10
 
 # We can set the PLC's timezone, which is largely cosmetic
 # See /usr/share/zoneinfo/ on the PLC for options
-plc_timezone:
+set_plc_timezone: false
+plc_timezone: America/Los_Angeles
 
 # This is the default of 32MB. Set to 67108864 for 64MB of router memory.
 tc_locked_memory_size_bytes: 33554432

--- a/group_vars/tcbsd_vms/vars.yml
+++ b/group_vars/tcbsd_vms/vars.yml
@@ -14,6 +14,9 @@ enable_freebsd_packages: true
 use_psproxy: false
 use_psntp: false
 
+# set static IP on x000 (mac id 2)
+x000_static:
+
 # We can set the PLC's timezone, which is largely cosmetic
 # See /usr/share/zoneinfo/ on the PLC for options
 plc_timezone:

--- a/host_vars/plc-tst-bsd/vars.yml
+++ b/host_vars/plc-tst-bsd/vars.yml
@@ -19,10 +19,12 @@ tc_ams_net_id: 172.21.148.81.1.1
 #use_psntp: true
 #
 # set static IP on x000 (mac id 2)
-#x000_static: 192.168.1.10
+#x000_set_static_ip: true
+#x000_static_ip: 192.168.1.10
 #
 ## We can set the PLC's timezone, which is largely cosmetic
 ## See /usr/share/zoneinfo/ on the PLC for options
+#set_plc_timezone: true
 #plc_timezone: America/Los_Angeles
 #
 ## This is the default of 32MB. Set to 67108864 for 64MB of router memory.

--- a/host_vars/plc-tst-bsd/vars.yml
+++ b/host_vars/plc-tst-bsd/vars.yml
@@ -14,6 +14,17 @@ tc_ams_net_id: 172.21.148.81.1.1
 ## point.
 #enable_freebsd_packages: true
 #
+## psproxy and psntp are currently needed to get bsd and package updates while on the lcls cds networks
+#use_psproxy: true
+#use_psntp: true
+#
+# set static IP on x000 (mac id 2)
+#x000_static: 192.168.1.10
+#
+## We can set the PLC's timezone, which is largely cosmetic
+## See /usr/share/zoneinfo/ on the PLC for options
+#plc_timezone: America/Los_Angeles
+#
 ## This is the default of 32MB. Set to 67108864 for 64MB of router memory.
 #tc_locked_memory_size_bytes: 33554432
 #

--- a/tcbsd-plc.yaml.template
+++ b/tcbsd-plc.yaml.template
@@ -18,6 +18,9 @@ tc_ams_net_id: ${PLC_NET_ID}
 #use_psproxy: true
 #use_psntp: true
 #
+## set static IP on x000 (mac id 2)
+#x000_static: 192.168.1.10
+#
 ## We can set the PLC's timezone, which is largely cosmetic
 ## See /usr/share/zoneinfo/ on the PLC for options
 #plc_timezone: America/Los_Angeles

--- a/tcbsd-plc.yaml.template
+++ b/tcbsd-plc.yaml.template
@@ -19,7 +19,8 @@ tc_ams_net_id: ${PLC_NET_ID}
 #use_psntp: true
 #
 ## set static IP on x000 (mac id 2)
-#x000_static: 192.168.1.10
+#x000_set_static_ip: true
+#x000_static_ip: 192.168.1.10
 #
 ## We can set the PLC's timezone, which is largely cosmetic
 ## See /usr/share/zoneinfo/ on the PLC for options

--- a/tcbsd-plc.yaml.template
+++ b/tcbsd-plc.yaml.template
@@ -14,6 +14,14 @@ tc_ams_net_id: ${PLC_NET_ID}
 ## point.
 #enable_freebsd_packages: true
 #
+## psproxy and psntp are currently needed to get bsd and package updates while on the lcls cds networks
+#use_psproxy: true
+#use_psntp: true
+#
+## We can set the PLC's timezone, which is largely cosmetic
+## See /usr/share/zoneinfo/ on the PLC for options
+#plc_timezone: America/Los_Angeles
+#
 ## This is the default of 32MB. Set to 67108864 for 64MB of router memory.
 #tc_locked_memory_size_bytes: 33554432
 #

--- a/tcbsd-provision-playbook.yaml
+++ b/tcbsd-provision-playbook.yaml
@@ -253,13 +253,14 @@
 
       # We use the second port as a LAN port with a known static IP
       # This makes it easy to use if we need it for e.g. doing service
-    - name: Set static IP on X001 (192.168.1.10 netmask 255.255.255.0)
-      register: static_ip_x001_set
+    - name: Set static IP on X000
+      when: x000_static != ""
+      register: static_ip_x000_set
       community.general.sysrc:
         name: ifconfig_igb1
-        value: inet 192.168.1.10 netmask 255.255.255.0
+        value: "inet {{ x000_static }} netmask 255.255.255.0"
 
-    - name: Reset X001
-      when: static_ip_x001_set.changed
+    - name: Reset X000
+      when: static_ip_x000_set.changed
       ansible.builtin.command: /etc/rc.d/netif restart igb1
       changed_when: true

--- a/tcbsd-provision-playbook.yaml
+++ b/tcbsd-provision-playbook.yaml
@@ -106,7 +106,7 @@
       ansible.builtin.pip:
         name: "{{ tc_install_pip_packages }}"
 
-    - name: Unstall pip
+    - name: Uninstall pip
       # Packages only available via pip will be installed before this
       # As far as the security implications go: well, that's up to you!
       when: tc_uninstall_pip

--- a/tcbsd-provision-playbook.yaml
+++ b/tcbsd-provision-playbook.yaml
@@ -17,6 +17,8 @@
       when: use_psproxy
       register: psproxy_setup
       ansible.builtin.blockinfile:
+        # Appending to this file lets us install packages from Beckhoff, etc.
+        # By using psproxy as our http/https proxy
         dest: /usr/local/etc/pkg.conf
         block: |
           PKG_ENV {
@@ -24,6 +26,8 @@
               https_proxy: "http://psproxy:3128",
           }
 
+    # We need NTP sync in order to install packages.
+    # Use internal ntp servers
     - name: Setup psntp
       when: use_psntp
       register: psntp_setup
@@ -44,16 +48,32 @@
     - name: Set timezone
       when: plc_timezone != ""
       ansible.builtin.copy:
+        # Strangely, copying a file is the designated way to set timezones.
         remote_src: true
         src: "/usr/share/zoneinfo/{{ plc_timezone }}"
         dest: /etc/localtime
 
-    - name: Restart NTP Service
+    # ntpd does not necessarily re-sync promptly after start or reconfig
+    # stop the service, sync manually, then start it again
+    # (cannot run sync manually if the service is running)
+    - name: Stop NTP Service
       when: psntp_setup.changed
       ansible.builtin.service:
         name: ntpd
         enabled: yes
-        state: restarted
+        state: stopped
+
+    - name: Force NTP Sync Now
+      when: psntp_setup.changed
+      ansible.builtin.command: ntpd -g -q
+      changed_when: true
+
+    - name: (Re) Start NTP Service
+      when: psntp_setup.changed
+      ansible.builtin.service:
+        name: ntpd
+        enabled: yes
+        state: started
 
     - name: Install helpful system packages
       ansible.builtin.package:
@@ -231,6 +251,8 @@
         state: restarted
       when: ams_net_id.changed or locked_memory_size.changed or heap_memory_size.changed
 
+      # We use the second port as a LAN port with a known static IP
+      # This makes it easy to use if we need it for e.g. doing service
     - name: Set static IP on X001 (192.168.1.10 netmask 255.255.255.0)
       register: static_ip_x001_set
       community.general.sysrc:
@@ -238,6 +260,6 @@
         value: inet 192.168.1.10 netmask 255.255.255.0
 
     - name: Reset X001
-      ansible.builtin.command: /etc/rc.d/netif restart igb1
       when: static_ip_x001_set.changed
+      ansible.builtin.command: /etc/rc.d/netif restart igb1
       changed_when: true

--- a/tcbsd-provision-playbook.yaml
+++ b/tcbsd-provision-playbook.yaml
@@ -15,6 +15,7 @@
 
     - name: Setup psproxy
       when: use_psproxy
+      register: psproxy_setup
       ansible.builtin.blockinfile:
         dest: /usr/local/etc/pkg.conf
         block: |
@@ -22,10 +23,10 @@
               http_proxy: "http://psproxy:3128",
               https_proxy: "http://psproxy:3128",
           }
-        register: psproxy_setup
 
     - name: Setup psntp
       when: use_psntp
+      register: psntp_setup
       ansible.builtin.blockinfile:
         dest: /etc/ntp.conf
         block: |
@@ -39,7 +40,6 @@
           server psntp1.pcdsn iburst
           server psntp2.pcdsn iburst
           server psntp3.pcdsn iburst
-        register: psntp_setup
 
     - name: Set timezone
       when: plc_timezone != ""
@@ -49,11 +49,11 @@
         dest: /etc/localtime
 
     - name: Restart NTP Service
+      when: psntp_setup.changed
       ansible.builtin.service:
         name: ntpd
         enabled: yes
         state: restarted
-      when: psntp_setup.changed
 
     - name: Install helpful system packages
       ansible.builtin.package:
@@ -86,8 +86,8 @@
       ansible.builtin.pip:
         name: "{{ tc_install_pip_packages }}"
 
-    - name: Install pip
-      # Packages only available via pip will be installed after this
+    - name: Unstall pip
+      # Packages only available via pip will be installed before this
       # As far as the security implications go: well, that's up to you!
       when: tc_uninstall_pip
       ansible.builtin.package:
@@ -232,10 +232,10 @@
       when: ams_net_id.changed or locked_memory_size.changed or heap_memory_size.changed
 
     - name: Set static IP on X001 (192.168.1.10 netmask 255.255.255.0)
+      register: static_ip_x001_set
       community.general.sysrc:
         name: ifconfig_igb1
         value: inet 192.168.1.10 netmask 255.255.255.0
-        register: static_ip_x001_set
 
     - name: Reset X001
       ansible.builtin.command: /etc/rc.d/netif restart igb1

--- a/tcbsd-provision-playbook.yaml
+++ b/tcbsd-provision-playbook.yaml
@@ -13,6 +13,48 @@
         path: /usr/local/etc/pkg/repos/FreeBSD.conf
         state: absent
 
+    - name: Setup psproxy
+      when: use_psproxy
+      ansible.builtin.blockinfile:
+        dest: /usr/local/etc/pkg.conf
+        block: |
+          PKG_ENV {
+              http_proxy: "http://psproxy:3128",
+              https_proxy: "http://psproxy:3128",
+          }
+        register: psproxy_setup
+
+    - name: Setup psntp
+      when: use_psntp
+      ansible.builtin.blockinfile:
+        dest: /etc/ntp.conf
+        block: |
+          disable monitor
+
+          # Permit time synchronization with our time source, but do not
+          # permit the source to query or modify the service on this system.
+          restrict default kod nomodify notrap nopeer noquery
+          restrict 127.0.0.1
+
+          server psntp1.pcdsn iburst
+          server psntp2.pcdsn iburst
+          server psntp3.pcdsn iburst
+        register: psntp_setup
+
+    - name: Set timezone
+      when: plc_timezone != ""
+      ansible.builtin.copy:
+        remote_src: true
+        src: "/usr/share/zoneinfo/{{ plc_timezone }}"
+        dest: /etc/localtime
+
+    - name: Restart NTP Service
+      ansible.builtin.service:
+        name: ntpd
+        enabled: yes
+        state: restarted
+      when: psntp_setup.changed
+
     - name: Install helpful system packages
       ansible.builtin.package:
         name:
@@ -188,3 +230,14 @@
         enabled: yes
         state: restarted
       when: ams_net_id.changed or locked_memory_size.changed or heap_memory_size.changed
+
+    - name: Set static IP on X001 (192.168.1.10 netmask 255.255.255.0)
+      community.general.sysrc:
+        name: ifconfig_igb1
+        value: inet 192.168.1.10 netmask 255.255.255.0
+        register: static_ip_x001_set
+
+    - name: Reset X001
+      ansible.builtin.command: /etc/rc.d/netif restart igb1
+      when: static_ip_x001_set.changed
+      changed_when: true

--- a/tcbsd-provision-playbook.yaml
+++ b/tcbsd-provision-playbook.yaml
@@ -46,7 +46,7 @@
           server psntp3.pcdsn iburst
 
     - name: Set timezone
-      when: plc_timezone != ""
+      when: set_plc_timezone
       ansible.builtin.copy:
         # Strangely, copying a file is the designated way to set timezones.
         remote_src: true
@@ -254,11 +254,11 @@
       # We use the second port as a LAN port with a known static IP
       # This makes it easy to use if we need it for e.g. doing service
     - name: Set static IP on X000
-      when: x000_static != ""
+      when: x000_set_static_ip
       register: static_ip_x000_set
       community.general.sysrc:
         name: ifconfig_igb1
-        value: "inet {{ x000_static }} netmask 255.255.255.0"
+        value: "inet {{ x000_static_ip }} netmask 255.255.255.0"
 
     - name: Reset X000
       when: static_ip_x000_set.changed


### PR DESCRIPTION
I think this is everything we need for people to be able to run the script reliably once and get all the settings for a PLC program + IOC to be able to work.
It's possible that we'll also need a plc restart step, I'll add one after the next "from factory" go if needed.

Main additions:
- configure psproxy, so plcs on the network can install from the bsd repositories. It's likely that one day we'll switch this out for local installs over the cds network but for now this makes everything work
- configure ntp, so the time/date is correct and the bsd servers don't reject us
- restart the ntp process and force a time/date sync
- set the timezone appropriately instead of staying on UTC
- optionally/configurable static ip on the second interface

Misc:
- Fix the order in the readme
- Re-establish the ansible config edit that makes the ssh not use the muxer (less efficient but at least it works at all...). I don't know why I needed this originally, didn't need it for a few days, and now need it again. For background, this simply blanks out the ansible default arguments that contain the control master stuff
- Various small wording tweaks