### PR TITLE
ENH: require config mode in order to run the provisioning playbook

### DIFF
--- a/tcbsd-provision-playbook.yaml
+++ b/tcbsd-provision-playbook.yaml
@@ -5,6 +5,18 @@
     - name: Verify connectivity with ping
       ansible.builtin.ping:
 
+    - name: Run PLC mode command
+      register: plc_mode
+      changed_when: false
+      ansible.builtin.command:
+        cmd: TcSysExe.exe --mode
+
+    - name: Assert that PLC is in CONFIG mode
+      ansible.builtin.assert:
+        that: "{{ 'CONFIG' in plc_mode.stdout }}"
+        fail_msg: "PLC is in RUN mode! Abort!"
+        quiet: true
+
     - name: Enable FreeBSD packages
       when: enable_freebsd_packages
       ansible.builtin.file:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
This makes the provisioning workflow refuse to proceed if the PLC is not in config mode, for example if it is in run mode or some invalid or error mode.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
From feedback in the TcBSD internal review: this is a simple way to stop ourselves from changing PLC configurations on active, running PLCs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively on plc-tst-bsd2:

When in run mode:
```
$ ./scripts/provision_plc.sh plc-tst-bsd2
TcBSD key is registered with ssh agent
BECOME password:

PLAY [plc-tst-bsd2] **************************************************************************************************************************************************************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************************************************************************************************************************************************************
ok: [plc-tst-bsd2]

TASK [Verify connectivity with ping] *********************************************************************************************************************************************************************************************************************************************************
ok: [plc-tst-bsd2]

TASK [Run PLC mode command] ******************************************************************************************************************************************************************************************************************************************************************
ok: [plc-tst-bsd2]

TASK [Assert that PLC is in CONFIG mode] *****************************************************************************************************************************************************************************************************************************************************
fatal: [plc-tst-bsd2]: FAILED! => {"assertion": false, "changed": false, "evaluated_to": false, "msg": "PLC is in RUN mode! Abort!"}

PLAY RECAP ***********************************************************************************************************************************************************************************************************************************************************************************
plc-tst-bsd2               : ok=3    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
```

When in config mode:
```
$ ./scripts/provision_plc.sh plc-tst-bsd2
TcBSD key is registered with ssh agent
BECOME password:

PLAY [plc-tst-bsd2] ******************************************************************************************************************************************

TASK [Gathering Facts] ***************************************************************************************************************************************
ok: [plc-tst-bsd2]

TASK [Verify connectivity with ping] *************************************************************************************************************************
ok: [plc-tst-bsd2]

TASK [Run PLC mode command] **********************************************************************************************************************************
ok: [plc-tst-bsd2]

TASK [Assert that PLC is in CONFIG mode] *********************************************************************************************************************
ok: [plc-tst-bsd2]

TASK [Enable FreeBSD packages] *******************************************************************************************************************************
skipping: [plc-tst-bsd2]

(continues)
```

I also verified that this check works from a fresh install.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
https://confluence.slac.stanford.edu/display/PCDS/TcBSD+Ansible+Workflows

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] Pre-commit passes on GitHub Actions
- [x] Documentation under https://confluence.slac.stanford.edu/display/PCDS/TcBSD has been updated appropriately
