### PR TITLE
ENH: option to dynamically set the AMS net id at runtime

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,6 +21,7 @@
 
 ## Pre-merge checklist
 - [ ] Code works interactively
+- [ ] Code works interactively in dry_run mode
 - [ ] Code contains descriptive docstrings, including context and API
 - [ ] Pre-commit passes on GitHub Actions
 - [ ] Documentation under https://confluence.slac.stanford.edu/display/PCDS/TcBSD has been updated appropriately

--- a/group_vars/tcbsd_plcs/vars.yml
+++ b/group_vars/tcbsd_plcs/vars.yml
@@ -11,6 +11,11 @@ enable_freebsd_packages: false
 use_psproxy: true
 use_psntp: true
 
+# Dynamic AMS net id = set AMS net id to ip addr .1.1
+# Static AMS net id = set AMS net id to the value of tc_ams_net_id
+dynamic_ams: true
+# tc_ams_net_id: 0.0.0.0.1.1
+
 # set static IP on x000 (mac id 2)
 x000_set_static_ip: true
 x000_static_ip: 192.168.1.10

--- a/group_vars/tcbsd_vms/vars.yml
+++ b/group_vars/tcbsd_vms/vars.yml
@@ -12,6 +12,10 @@ enable_freebsd_packages: false
 use_psproxy: false
 use_psntp: false
 
+# Dynamic AMS net id = set AMS net id to ip addr .1.1
+# Static AMS net id = set AMS net id to the value of tc_ams_net_id
+dynamic_ams: false
+
 # set static IP on x000 (mac id 2)
 x000_set_static_ip: false
 x000_static_ip: 192.168.1.10

--- a/host_vars/plc-tmo-tmp-vac/vars.yml
+++ b/host_vars/plc-tmo-tmp-vac/vars.yml
@@ -1,6 +1,5 @@
 ---
 ansible_host: plc-tmo-tmp-vac
-tc_ams_net_id: 172.21.132.78.1.1
 
 # Uncomment any setting below and change it to override a default setting.
 #ansible_user: Administrator
@@ -14,6 +13,11 @@ tc_ams_net_id: 172.21.132.78.1.1
 ## psproxy and psntp are currently needed to get bsd and package updates while on the lcls cds networks
 #use_psproxy: true
 #use_psntp: true
+#
+## Dynamic AMS net id = set AMS net id to ip addr .1.1
+## Static AMS net id = set AMS net id to the value of tc_ams_net_id
+#dynamic_ams: true
+## tc_ams_net_id: 0.0.0.0.1.1
 #
 ## set static IP on x000 (mac id 2)
 #x000_set_static_ip: true

--- a/host_vars/plc-tst-bsd1/vars.yml
+++ b/host_vars/plc-tst-bsd1/vars.yml
@@ -1,6 +1,5 @@
 ---
 ansible_host: plc-tst-bsd1
-tc_ams_net_id: 172.21.148.81.1.1
 
 # Uncomment any setting below and change it to override a default setting.
 #ansible_user: Administrator
@@ -14,6 +13,11 @@ tc_ams_net_id: 172.21.148.81.1.1
 ## psproxy and psntp are currently needed to get bsd and package updates while on the lcls cds networks
 #use_psproxy: true
 #use_psntp: true
+#
+## Dynamic AMS net id = set AMS net id to ip addr .1.1
+## Static AMS net id = set AMS net id to the value of tc_ams_net_id
+#dynamic_ams: true
+## tc_ams_net_id: 0.0.0.0.1.1
 #
 ## set static IP on x000 (mac id 2)
 #x000_set_static_ip: true

--- a/host_vars/plc-tst-bsd2/vars.yml
+++ b/host_vars/plc-tst-bsd2/vars.yml
@@ -1,6 +1,5 @@
 ---
 ansible_host: plc-tst-bsd2
-tc_ams_net_id: 172.21.148.94.1.1
 
 # Uncomment any setting below and change it to override a default setting.
 #ansible_user: Administrator
@@ -14,6 +13,11 @@ tc_ams_net_id: 172.21.148.94.1.1
 ## psproxy and psntp are currently needed to get bsd and package updates while on the lcls cds networks
 #use_psproxy: true
 #use_psntp: true
+#
+## Dynamic AMS net id = set AMS net id to ip addr .1.1
+## Static AMS net id = set AMS net id to the value of tc_ams_net_id
+#dynamic_ams: true
+## tc_ams_net_id: 0.0.0.0.1.1
 #
 ## set static IP on x000 (mac id 2)
 #x000_set_static_ip: true

--- a/ip_macros.j2
+++ b/ip_macros.j2
@@ -1,5 +1,5 @@
 {%- macro ip_to_ams_net_id(hostname) -%}
-{%- set ipaddr = lookup('dig', hostname) -%}
+{%- set ipaddr = lookup('community.general.dig', hostname, fail_on_error=True) -%}
 {{ ipaddr }}.1.1
 {%- endmacro -%}
 

--- a/tcbsd-provision-playbook.yaml
+++ b/tcbsd-provision-playbook.yaml
@@ -12,6 +12,7 @@
         cmd: TcSysExe.exe --mode
 
     - name: Assert that PLC is in CONFIG mode
+      when: not ansible_check_mode
       ansible.builtin.assert:
         that: "{{ 'CONFIG' in plc_mode.stdout }}"
         fail_msg: "PLC is in RUN mode! Abort!"

--- a/tcbsd-provision-playbook.yaml
+++ b/tcbsd-provision-playbook.yaml
@@ -156,7 +156,12 @@
       community.general.xml:
         path: /usr/local/etc/TwinCAT/3.1/TcRegistry.xml
         xpath: /TcRegistry/Key[@Name='HKLM']/Key[@Name='Software']/Key[@Name='Beckhoff']/Key[@Name='TwinCAT3']/Key[@Name='System']/Value[@Name='AmsNetId']
-        value: "{% import 'ip_macros.j2' as ip_macros %}{{ ip_macros.ams_net_id_to_binary(tc_ams_net_id) }}"
+        value: >-
+          {%- import 'ip_macros.j2' as ip_macros -%}
+          {%- if dynamic_ams -%}
+          {%- set tc_ams_net_id = ip_macros.ip_to_ams_net_id(ansible_host) -%}
+          {%- endif -%}
+          {{ ip_macros.ams_net_id_to_binary(tc_ams_net_id) }}
       register: ams_net_id
 
     - name: Adjust the locked memory size


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add a (default: true) option for setting the ams net id dynamically at runtime based on the current IP address.
This remains (default: false) for the vms for backcompat.

Built on top of #17 and includes the commits from that PR

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
An issue was brought up in the review that it'd be great to use these scripts to help us avoid ams net id collisions. This also goes a step further and helps us never need to manually set an ams net id ever again.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively I verified that this pulled the correct ams net id for the test plcs and that the non-dynamic mode could still be used.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Added a small note to https://confluence.slac.stanford.edu/display/PCDS/TcBSD+Ansible+Workflows

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] Pre-commit passes on GitHub Actions
- [x] Documentation under https://confluence.slac.stanford.edu/display/PCDS/TcBSD has been updated appropriately
