### PR TITLE
ENH: prepare PLC for pmpsdb_client

### DIFF
--- a/group_vars/tcbsd_plcs/vars.yml
+++ b/group_vars/tcbsd_plcs/vars.yml
@@ -16,6 +16,10 @@ use_psntp: true
 dynamic_ams: true
 # tc_ams_net_id: 0.0.0.0.1.1
 
+# Extra user for non-admin activities
+create_user: true
+create_username: ecs-user
+
 # set static IP on x000 (mac id 2)
 x000_set_static_ip: true
 x000_static_ip: 192.168.1.10

--- a/group_vars/tcbsd_vms/vars.yml
+++ b/group_vars/tcbsd_vms/vars.yml
@@ -16,6 +16,10 @@ use_psntp: false
 # Static AMS net id = set AMS net id to the value of tc_ams_net_id
 dynamic_ams: false
 
+# Extra user for non-admin activities
+create_user: false
+# create_username:
+
 # set static IP on x000 (mac id 2)
 x000_set_static_ip: false
 x000_static_ip: 192.168.1.10

--- a/host_vars/plc-tmo-tmp-vac/vars.yml
+++ b/host_vars/plc-tmo-tmp-vac/vars.yml
@@ -19,6 +19,10 @@ ansible_host: plc-tmo-tmp-vac
 #dynamic_ams: true
 ## tc_ams_net_id: 0.0.0.0.1.1
 #
+## Extra user for non-admin activities
+#create_user: true
+#create_username: ecs-user
+#
 ## set static IP on x000 (mac id 2)
 #x000_set_static_ip: true
 #x000_static_ip: 192.168.1.10

--- a/host_vars/plc-tst-bsd1/vars.yml
+++ b/host_vars/plc-tst-bsd1/vars.yml
@@ -19,6 +19,10 @@ ansible_host: plc-tst-bsd1
 #dynamic_ams: true
 ## tc_ams_net_id: 0.0.0.0.1.1
 #
+## Extra user for non-admin activities
+#create_user: true
+#create_username: ecs-user
+#
 ## set static IP on x000 (mac id 2)
 #x000_set_static_ip: true
 #x000_static_ip: 192.168.1.10

--- a/host_vars/plc-tst-bsd2/vars.yml
+++ b/host_vars/plc-tst-bsd2/vars.yml
@@ -19,6 +19,10 @@ ansible_host: plc-tst-bsd2
 #dynamic_ams: true
 ## tc_ams_net_id: 0.0.0.0.1.1
 #
+## Extra user for non-admin activities
+#create_user: true
+#create_username: ecs-user
+#
 ## set static IP on x000 (mac id 2)
 #x000_set_static_ip: true
 #x000_static_ip: 192.168.1.10

--- a/tcbsd-provision-playbook.yaml
+++ b/tcbsd-provision-playbook.yaml
@@ -340,3 +340,32 @@
       when: static_ip_x001_set.changed or dhcp_x001_set.changed
       ansible.builtin.wait_for_connection:
         delay: 2
+
+    # Useful for apps that need PLC access but not Admin-level config change access
+    # We need to manually set the password ourselves later via "doas passwd username"
+    - name: Create or Remove non-admin User
+      ansible.builtin.user:
+        name: "{{ create_username }}"
+        state: "{{ create_user | ternary('present', 'absent') }}"
+        shell: /usr/local/bin/bash'
+
+    # By default, only pubkey and keyboard interactive are enabled
+    # Password access is useful for apps like pmpsdb_client
+    - name: Configure sshd for password access
+      register: sshd_configure
+      ansible.builtin.lineinfile:
+        path: /etc/ssh/sshd_config
+        line: "PasswordAuthentication yes"
+        insertafter: "^#PasswordAuthentication"
+
+    - name: Reload sshd
+      when: sshd_configure.changed
+      ansible.builtin.service:
+        name: sshd
+        enabled: yes
+        state: reloaded
+
+    - name: Verify ssh still works
+      when: sshd_configure.changed
+      ansible.builtin.wait_for_connection:
+        delay: 2


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Adds in four ansible tasks intended for making PLCs ready for use by the pmpsdb_client.
The tasks are as follows:

- Create the non-admin "ecs-user" user
- Configure sshd for password access
- Reload the sshd service to pick up the new config
- Verify that ssh still works

Creating this user can be disabled (and is disabled by default for vms), and it can also be customized to create a different user. The user can be removed later.

Even if the user is created, there must be a manual step to set its password, which ansible does not let you set via file-based plaintext. So, in no cases is a usable automatic extra login created.

This is related to:
https://github.com/pcdshub/lcls-twincat-motion/pull/215
https://github.com/pcdshub/pmpsdb_client/pull/25

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- The non-admin user will be used for PLC configuration tasks that do not need elevated permissions.
- Reading and writing the PMPS database file does not need elevated permissions, allowing non-experts to be able to do it without needing access to the admin password and through application software.
- Python's ssh libraries (fabric/paramiko/intake) behave much better with "password" auth enabled (as opposed to only "KeyboardInteractive" (password) auth, which is what is enabled by default). Functionally, the two of these are the same from the user perspective as implement by the TcBSD OS.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively with my test PLC

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
https://confluence.slac.stanford.edu/display/PCDS/TcBSD+Ansible+Workflows#TcBSDAnsibleWorkflows-Playbook.1

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code works interactively in dry_run mode
- [x] Code contains descriptive docstrings, including context and API
- [x] Pre-commit passes on GitHub Actions
- [x] Documentation under https://confluence.slac.stanford.edu/display/PCDS/TcBSD has been updated appropriately
