### PR TITLE
ENH: prompt user to update deployment docs, providing the necessary info to do so

### DIFF
--- a/scripts/docs_prompt.sh
+++ b/scripts/docs_prompt.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Get version info for inclusion on https://confluence.slac.stanford.edu/x/0IsFGg
+# Includes a human-readable shorthand, a url to the commit, and the current time and date
+THIS_SCRIPT="$(realpath "${0}")"
+THIS_DIR="$(dirname "${THIS_SCRIPT}")"
+
+VERSION="$(git -C "${THIS_DIR}" describe --tags)"
+URL="https://github.com/pcdshub/twincat-bsd-ansible/tree/${VERSION}"
+
+echo "If you made changes, please update the deployment docs (https://confluence.slac.stanford.edu/x/0IsFGg)"
+echo "TcBSD Ansible Version: ${VERSION}"
+echo "Link commit URL: ${URL}"
+echo "PLC Updated on: $(date +'%b %d, %Y')"

--- a/scripts/provision_plc.sh
+++ b/scripts/provision_plc.sh
@@ -35,3 +35,6 @@ ansible-playbook "${ANSIBLE_ROOT}/tcbsd-provision-playbook.yaml" --extra-vars "t
 
 # Stop the ssh agent if we started it here
 ssh_agent_helper_cleanup
+
+# Prompt to update deployment docs
+"${THIS_DIR}"/docs_prompt.sh


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
After running the ansible script, prompt the user to update the deployment documentation.
```
If you made changes, please update the deployment docs (https://confluence.slac.stanford.edu/x/0IsFGg)
TcBSD Ansible Version: v0.1.0-54-g24b4a11
Link commit URL: https://github.com/pcdshub/twincat-bsd-ansible/tree/v0.1.0-54-g24b4a11
PLC Updated on: Mar 26, 2024
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I'd like to keep the current deployments docs page as up-to-date as possible to keep track of our deployments. Doing this as we go is more likely to succeed than trying to run after the information later. Providing all the info needed so the engineer doesn't need to go digging for anything should get us to a point of minimum barrier of entry.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
This is mentioned on the plc setup page, the ansible workflows page, and on the current deployments docs page (all on confluence)

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code works interactively in dry_run mode
- [x] Code contains descriptive docstrings, including context and API
- [x] Pre-commit passes on GitHub Actions
- [x] Documentation under https://confluence.slac.stanford.edu/display/PCDS/TcBSD has been updated appropriately
