### PR TITLE
BUG: fixes for inventory management bugs

### DIFF
--- a/scripts/bootstrap_plc.sh
+++ b/scripts/bootstrap_plc.sh
@@ -36,7 +36,7 @@ if grep -q "${HOSTNAME}:" "${INVENTORY_PATH}"; then
   echo "Found ${HOSTNAME} in ${INVENTORY_PATH}."
 else
   # Add PLC to inventory
-  python "${THIS_DIR}"/add_to_inventory.py "${1}"
+  python "${THIS_DIR}"/add_to_inventory.py "${HOSTNAME}"
 fi
 
 # Create vars, if they do not already exist


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Fix a bug where empty string or arbitrary command-line arguments would be used instead of the hostname during setup
- Fix a bug where empty host groups could not be added to
- Make sure this script will still work if we start using sub-element configuration in the inventory
- Make the type hinting for the `_Inventory` alias very verbose to help me fix the empty host groups

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- The setup scripts are intended to add your PLC to the ansible inventory semi-automatically, only prompting for picking a group.
- Currently, this breaks down in several ways. See https://jira.slac.stanford.edu/browse/ECS-4976
- Continue using yaml directly rather than use the ansible config API because ansible says that their config file API should be considered internal/not public/not stable

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively by adding hostnames to empty groups

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here + jira

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code works interactively in dry_run mode
- [x] Code contains descriptive docstrings, including context and API
- [x] Pre-commit passes on GitHub Actions
- [x] Documentation under https://confluence.slac.stanford.edu/display/PCDS/TcBSD has been updated appropriately
