### PR TITLE
BUG: add git safe directory for centrally deployed git repos

### DIFF
--- a/scripts/docs_prompt.sh
+++ b/scripts/docs_prompt.sh
@@ -3,8 +3,14 @@
 # Includes a human-readable shorthand, a url to the commit, and the current time and date
 THIS_SCRIPT="$(realpath "${0}")"
 THIS_DIR="$(dirname "${THIS_SCRIPT}")"
+source "${THIS_DIR}"/paths.sh
 
-VERSION="$(git -C "${THIS_DIR}" describe --tags)"
+# Safe directory needed to check the git version, only apply once per user.
+if ! git config --global --get-all safe.directory | grep "${ANSIBLE_ROOT}" &>/dev/null; then
+    git config --global --add safe.directory "${ANSIBLE_ROOT}"
+    echo "Added ${ANSIBLE_ROOT} as a git safe.directory to check the version."
+fi
+VERSION="$(git -C "${ANSIBLE_ROOT}" describe --tags)"
 URL="https://github.com/pcdshub/twincat-bsd-ansible/tree/${VERSION}"
 
 echo "If you made changes, please update the deployment docs (https://confluence.slac.stanford.edu/x/0IsFGg)"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- If it has not already been done, add the ansible root directory as a safe directory for the purposes of git when we need to use git to check the version number.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- After running a plc setup, we are supposed to document the results.
- Providing some version information to the user at exit is really helpful for making it possible to complete this step.
- "git describe" is the simplest way to get this information
- All git commands refuse to run for shared directories unless safe.directory has an entry for the cloned git repo path.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Interactively only, as me

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
- Only here and in jira

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code works interactively in dry_run mode
- [x] Code contains descriptive docstrings, including context and API
- [x] Pre-commit passes on GitHub Actions
- [x] Documentation under https://confluence.slac.stanford.edu/display/PCDS/TcBSD has been updated appropriately
