### PR TITLE
CI/AUTO: SHA Pinning and Dependabot

### DIFF
--- a/.github/dependabot_template.yml
+++ b/.github/dependabot_template.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+      exclude:
+      - pcdshub/pcds-ci-helpers/*

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,6 +10,6 @@ on:
 jobs:
   pre-commit:
     name: "pre-commit checks"
-    uses: pcdshub/pcds-ci-helpers/.github/workflows/pre-commit.yml@master
+    uses: pcdshub/pcds-ci-helpers/.github/workflows/pre-commit.yml@2e7e5ec8fb8afca5fa0cdb60b82b0f1b99cd2647
     with:
       args: "--all-files"


### PR DESCRIPTION

# SHA Pinning

We are now required to pin GitHub Actions to specific SHAs.
This PR automatically updates all actions to a somewhat recent SHA.
It also configures dependabot to update the SHAs for us on a monthly basis.

If this PR is not merged, all GitHub Actions Workflows in this repository
will stop working at the end of June 2026.

See https://jira.slac.stanford.edu/browse/ECS-10557

## Code Review

For reviewers: our task is to pick one of:

- Merge as-is, then fix the CI if needed
- Fix the CI, and then merge
- Close this PR and archive the repo
- Merge this PR and archive the repo
- Remove the GitHub Actions configuration from the repo,
  then close this PR.
- Ignore this PR until we use the repo again
